### PR TITLE
set default instance size to Standard_B2s

### DIFF
--- a/aks-cluster.tf
+++ b/aks-cluster.tf
@@ -22,7 +22,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   default_node_pool {
     name            = "default"
     node_count      = 2
-    vm_size         = "Standard_D2_v2"
+    vm_size         = "Standard_B2s"
     os_disk_size_gb = 30
   }
 


### PR DESCRIPTION
Cloning this repository and running a `terraform apply` errors out with the following:

```
│ Error: creating Managed Kubernetes Cluster "open-gazelle-aks" (Resource Group "open-gazelle-rg"): containerservice.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="BadRequest" Message="The VM size of AgentPoolProfile:default is not allowed in your subscription in location 'westus2'. The available VM sizes are 'standard_d15_v2,standard_d16pds_v5,standard_d16plds_v5,standard_d16pls_v5,standard_d16ps_v5,standard_d2pds_v5,standard_d2plds_v5,standard_d2pls_v5,standard_d2ps_v5,standard_d32pds_v5,standard_d32plds_v5,standard_d32pls_v5,standard_d32ps_v5,standard_d48pds_v5,standard_d48plds_v5,standard_d48pls_v5,standard_d48ps_v5,standard_d4pds_v5,standard_d4plds_v5,standard_d4pls_v5,standard_d4ps_v5,standard_d64pds_v5,standard_d64plds_v5,standard_d64pls_v5,standard_d64ps_v5,standard_d8pds_v5,standard_d8plds_v5,standard_d8pls_v5,standard_d8ps_v5,standard_ds15_v2,standard_e16pds_v5,standard_e16ps_v5,standard_e20pds_v5,standard_e20ps_v5,standard_e2pds_v5,standard_e2ps_v5,standard_e32pds_v5,standard_e32ps_v5,standard_e4pds_v5,standard_e4ps_v5,standard_e8pds_v5,standard_e8ps_v5,standard_fx12mds,standard_fx24mds,standard_fx36mds,standard_fx48mds,standard_fx4mds,standard_hb120-16rs_v2,standard_hb120-32rs_v2,standard_hb120-64rs_v2,standard_hb120-96rs_v2,standard_hb120rs_v2,standard_hc44-16rs,standard_hc44-32rs,standard_hc44rs,standard_nc12s_v3,standard_nc24rs_v3,standard_nc24s_v3,standard_nc6s_v3,standard_nv12ads_a10_v5,standard_nv12s_v3,standard_nv16as_v4,standard_nv18ads_a10_v5,standard_nv24s_v3,standard_nv32as_v4,standard_nv36adms_a10_v5,standard_nv36ads_a10_v5,standard_nv48s_v3,standard_nv4as_v4,standard_nv6ads_a10_v5,standard_nv72ads_a10_v5,standard_nv8as_v4' For more details, please visit https://aka.ms/aks/quotas-skus-regions"
```

From my understanding, the preferred instance across Learn tutorials is **Standard_B2s**.

