### PR TITLE
update versions to work on current Azure

### DIFF
--- a/aks-cluster.tf
+++ b/aks-cluster.tf
@@ -21,12 +21,12 @@ resource "azurerm_kubernetes_cluster" "default" {
   location            = azurerm_resource_group.default.location
   resource_group_name = azurerm_resource_group.default.name
   dns_prefix          = "${random_pet.prefix.id}-k8s"
-  kubernetes_version  = "1.26.3"
+  kubernetes_version  = "1.33.2"
 
   default_node_pool {
     name            = "default"
     node_count      = 2
-    vm_size         = "Standard_D2_v2"
+    vm_size         = "Standard_D2_v4"
     os_disk_size_gb = 30
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.67.0"
+      version = "~>3.0"
     }
   }
 


### PR DESCRIPTION
- Update vm_size from Standard Dv2 to Standard Dv4
- Update kubernetes_version to 1.33.2 as 1.26.3 is no longer available
- Update azurerm version to "~>3.0" for compatibility with current Azure API.